### PR TITLE
Log 'x-request-id'

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,9 @@
 const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
-const logger = require('morgan');
+const logger = require('./logger');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
-const fs = require('fs');
 
 const routes = require('./routes/index');
 const users = require('./routes/users');
@@ -36,13 +35,7 @@ app.use(favicon(path.join(__dirname,
   'vendor', 'govuk_template_mustache_inheritance', 'assets', 'images', 'favicon.ico')));
 
 // Configure logging
-if (app.get('env') === 'test') {
-  app.use(logger('tiny', {
-    stream: fs.createWriteStream(`${__dirname}/logs/test.log`, { flags: 'w' }),
-  }));
-} else {
-  app.use(logger('dev'));
-}
+app.use(logger.init(app.get('env')));
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ gulp.task('server', () => {
 });
 
 gulp.task('watch', ['css', 'server'], () => {
-  gulp.watch(['routes/**/*.js', 'app.js'], ['server']);
+  gulp.watch(['routes/**/*.js', '*.js'], ['server']);
   gulp.watch('assets/stylesheets/*.scss', ['css']);
 });
 

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,53 @@
+const morgan = require('morgan');
+const fs = require('fs');
+
+function colorForStatus(status) {
+  if (status >= 500) {
+    return 31; // red
+  }
+  if (status >= 400) {
+    return 33; // yellow
+  }
+  if (status >= 300) {
+    return 36; // cyan
+  }
+  if (status >= 200) {
+    return 32; // green
+  }
+  return 0; // no color
+}
+
+morgan.format('dev+', function developmentFormatLine(tokens, req, res) {
+  // eslint-disable-next-line
+  'use strict';
+  // get the status code if response written
+  // eslint-disable-next-line no-underscore-dangle
+  const status = res._header
+    ? res.statusCode
+    : undefined;
+
+  // get status color
+  const color = colorForStatus(status);
+
+  // get colored function
+  let fn = developmentFormatLine[color];
+
+  if (!fn) {
+    // compile
+    // eslint-disable-next-line
+    fn = developmentFormatLine[color] = morgan.compile('\x1b[0m:method :url \x1b['
+      + color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m ' +
+      ':req[x-request-id]');
+  }
+
+  return fn(tokens, req, res);
+});
+
+module.exports.init = (env) => {
+  if (env === 'test') {
+    return morgan('tiny', {
+      stream: fs.createWriteStream(`${__dirname}/logs/test.log`, { flags: 'w' }),
+    });
+  }
+  return morgan('dev+');
+};


### PR DESCRIPTION
- x-request-id header logged
- support for colors in log status