### PR TITLE
Add generic govuk cookies page applicable to lmt

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,6 +7,7 @@ const bodyParser = require('body-parser');
 
 const indexController = require('./controllers/index-controller');
 const usersController = require('./controllers/users-controller');
+const cookieController = require('./controllers/cookie-controller');
 const i18n = require('./middleware/i18n');
 const errorHandler = require('./middleware/error-handler');
 const healthCheckController = require('./controllers/health-check-controller');
@@ -68,6 +69,7 @@ app.use(assetPath, express.static(path.join(__dirname, '..',
 app.use(helmet.noCache());
 
 app.use(`${basePath}/`, indexController);
+app.use(`${basePath}/`, cookieController);
 app.use(`${basePath}/users`, usersController);
 
 // catch 404 and forward to error handler

--- a/app/controllers/cookie-controller.js
+++ b/app/controllers/cookie-controller.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-underscore-dangle */
+const express = require('express');
+const router = new express.Router();
+
+router.get('/cookie', (req, res) => {
+  res.render('cookie');
+});
+
+module.exports = router;

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2,6 +2,11 @@
   "main": {
     "title": "Welcome from i18n"
   },
+  "cookie": {
+    "pretext": "GOV.UK uses cookies to make the site simpler",
+    "linktext": "Find out more about cookies",
+    "pagetitle": "Cookie"
+  },
   "error": {
     "404": "Page not found",
     "500": "We're experiencing technical problems."

--- a/app/views/cookie.mustache
+++ b/app/views/cookie.mustache
@@ -1,0 +1,118 @@
+{{<layout}}
+{{$pageTitle}}{{#__}}cookie.pagetitle{{/__}}{{/pageTitle}}
+{{$applicationContent}}
+
+<header class="page-header">
+  <div>
+    <h1 class="heading-xlarge" data-test="cookie-title">
+      Cookies
+    </h1>
+  </div>
+</header>
+<div class="article-container group">
+  <div class="content-block">
+    <div class="inner">
+      <div class="summary">
+        <p>This site puts small files (known as ‘cookies’) onto your computer to collect information
+          about how you browse the site.</p>
+      </div>
+
+      <p>Cookies are used to: </p>
+
+      <ul class="list list-bullet">
+        <li>measure how you use the website so it can be updated and improved based on your needs
+        </li>
+        <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+      </ul>
+
+      <div class="application-notice info-notice">
+        <p>Our cookies aren’t used to identify you personally.</p>
+      </div>
+
+      <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
+
+      <p>Find out more about <a rel="external" href="http://www.aboutcookies.org/">how to manage
+        cookies.</a></p>
+
+      <h2 class="heading-large">How we use cookies</h2>
+
+      <h3 class="heading-medium">Measuring website usage (Google Analytics)</h3>
+
+      <p>We use Google Analytics software to collect information about how you use this site. We do
+        this to help make sure the site is meeting the needs of its users and to help us make
+        improvements.</p>
+
+      <p>Google Analytics stores information about:</p>
+
+      <ul class="list list-bullet">
+        <li>the pages you visit</li>
+        <li>how long you spend on each page</li>
+        <li>how you got to the site</li>
+        <li>what you click on and search for while you’re visiting the site</li>
+      </ul>
+
+      <p>We don’t collect or store your personal information (eg your name or address) so this
+        information can’t be used to identify who you are. </p>
+
+      <div class="application-notice info-notice">
+        <p>We don’t allow Google to use or share our analytics data.</p>
+      </div>
+
+      <p>Google Analytics sets the following cookies:</p>
+
+      <h3 class="heading-medium">Universal Analytics</h3>
+
+      <table>
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Purpose</th>
+          <th>Expires</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>_ga</td>
+          <td>This helps us count how many people visit this site by tracking if you’ve visited
+            before
+          </td>
+          <td>2 years</td>
+        </tr>
+        <tr>
+          <td>_gat</td>
+          <td>Used to manage the rate at which page view requests are made</td>
+          <td>10 minutes</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <p>You can <a rel="external" href="https://tools.google.com/dlpage/gaoptout">opt out of Google
+        Analytics cookies.</a></p>
+
+      <h3 class="heading-medium">Our introductory message</h3>
+
+      <p>You may see a pop-up welcome message when you first visit this site. We’ll store a cookie
+        so that your computer knows you’ve seen it and knows not to show it again.</p>
+
+      <table>
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Purpose</th>
+          <th>Expires</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>seen_cookie_message</td>
+          <td>Saves a message to let us know that you’ve seen our cookie message</td>
+          <td>1 month</td>
+        </tr>
+        </tbody>
+      </table>
+
+    </div>
+  </div>
+</div>
+{{/applicationContent}}
+{{/layout}}

--- a/app/views/layouts/main.mustache
+++ b/app/views/layouts/main.mustache
@@ -4,6 +4,10 @@
     <link href="{{{ assetPath }}}stylesheets/style.css" media="screen" rel="stylesheet" type="text/css"/>
   {{/head}}
 
+  {{$cookieMessage}}
+    {{#__}}cookie.pretext{{/__}}. <a href="{{ basePath }}/cookie">{{#__}}cookie.linktext{{/__}}</a>
+  {{/cookieMessage}}
+
   {{$bodyStart}}
   {{>googleTagManager}}
   {{/bodyStart}}

--- a/test/common/page_objects/cookie-page.js
+++ b/test/common/page_objects/cookie-page.js
@@ -1,0 +1,15 @@
+class CookiePage {
+  constructor(browser) {
+    this.browser = browser;
+  }
+
+  visit() {
+    return this.browser.visit('/cookie');
+  }
+
+  isDisplayed() {
+    return !! this.browser.text('[data-test="cookie-title"]');
+  }
+
+}
+module.exports = CookiePage;

--- a/test/integration/cookie.spec.js
+++ b/test/integration/cookie.spec.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-underscore-dangle */
+const helper = require('./support/integrationSpecHelper');
+const googleTagManagerHelper = helper.googleTagManagerHelper;
+const cookiePage = helper.cookiePage;
+const expect = require('chai').expect;
+
+describe('Cookie page', () => {
+  before(() =>
+    cookiePage.visit()
+  );
+
+  it('should contain valid googleTagManager', () =>
+    expect(googleTagManagerHelper.getUserVariable()).to.exists
+  );
+
+  it('displays govuk general cookie info', () =>
+    expect(cookiePage.isDisplayed()).to.equal(true)
+  );
+});

--- a/test/integration/support/integrationSpecHelper.js
+++ b/test/integration/support/integrationSpecHelper.js
@@ -5,6 +5,7 @@ const screenshots = require('./screenshots');
 const GoogleTagManagerHelper = require('../../common/page_objects/google-tag-manager-helper');
 const MainPage = require('../../common/page_objects/main-page');
 const ErrorPage = require('../../common/page_objects/error-page');
+const CookiePage = require('../../common/page_objects/cookie-page');
 
 process.env.GOOGLE_TAG_MANAGER_ID = 'fake-id';
 const app = require('../../../bin/www');
@@ -20,5 +21,6 @@ module.exports = {
   googleTagManagerHelper: new GoogleTagManagerHelper(browser),
   mainPage: new MainPage(browser),
   errorPage: new ErrorPage(browser),
+  cookiePage: new CookiePage(browser),
   app,
 };


### PR DESCRIPTION
 * Adds cookie page on /cookie that describes generic cookies in use on lmt projects
 * Adds cookie message to default layout, as per spec